### PR TITLE
Bumped down depends to 3.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Version: 0.2
 Authors@R: person("Joseph", "Stachelek", email = "stachel2@msu.edu", role = c("aut", "cre"))
 Description: R interface to the National Lakes Assessment.
 Depends:
-    R (>= 3.3.2)
+    R (>= 3.0.0)
 Imports: rappdirs
 URL: https://github.com/jsta/nlaR
 BugReports: https://github.com/jsta/nlaR/issues


### PR DESCRIPTION
Depends was on 3.3.2.  That makes it break on anything older than a few months!

I bumped it down to 3.0.0 since that is likely OK and a universal expectation.

Merge as you see fit!  And nice job!