### PR TITLE
minor fix with download paths

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -21,7 +21,7 @@ nla_get <- function(year, dest_folder = NA){
     files   <- "nla2007_alldata.zip"
 
     invisible(lapply(files, function(x) get_if_not_exists(paste0(baseurl, x),
-                                        paste0(nla_path(), x))))
+                                        file.path(nla_path(), x))))
 
     unzip(file.path(nla_path(), files), exdir = nla_path())
   }
@@ -41,7 +41,7 @@ nla_get <- function(year, dest_folder = NA){
       "nla2012_chla_wide.csv")
 
     invisible(lapply(files, function(x) get_if_not_exists(paste0(baseurl, x),
-                                        paste0(nla_path(), x))))
+                                        file.path(nla_path(), x))))
 
     baseurl <- "https://www.epa.gov/sites/production/files/2016-12/"
     files <- c(
@@ -59,7 +59,7 @@ nla_get <- function(year, dest_folder = NA){
       "nla2012_zooptaxa_wide_10272015.csv")
 
     invisible(lapply(files, function(x) get_if_not_exists(paste0(baseurl, x),
-                                        paste0(nla_path(), x))))
+                                        file.path(nla_path(), x))))
   }
 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,5 @@
 
-nla_path <- function() paste0(rappdirs::user_data_dir(appname = "nlaR"))
+nla_path <- function() file.path(rappdirs::user_data_dir(), "nlaR")
 
 get_if_not_exists <- function(url, destfile){
   if(!file.exists(destfile)){


### PR DESCRIPTION
The `rappdirs::user_data_dir` function in `nla_path()` was creating a path like this:

"C:\\Users\\MARCUS~1.SCC\\AppData\\Local\\nlaR\\nlaR"

When it should've looked like this:

"C:\\Users\\MARCUS.SCCWRP2K\\AppData\\Local\\nlaR\\nlaR"

The changes in this commit should fix this. I tested `nla_get`, `nla_compile`, and `nla_load` for the 2007 and 2012 data and it worked fine.  
